### PR TITLE
Fixed wrong link in `index.html`

### DIFF
--- a/index.html
+++ b/index.html
@@ -250,7 +250,7 @@ document.getElementById("repl").style.display = "block";
       </li>
 
       <li class="som-impl">
-        <h4><a href="https://github.com/SOM-st/JsSOM">SOM-RS</a></h4>
+        <h4><a href="https://github.com/Hirevo/som-rs">SOM-RS</a></h4>
         <ul>
           <li>abstract-syntax-tree-based or bytecode-based, in Rust</li>
           <li>some optimizations, very similar to other SOM implementations</li>


### PR DESCRIPTION
This PR simply fixes the link for `som-rs` that mistakenly redirected to the JsSOM repository.